### PR TITLE
fix for glider slocum drift issue

### DIFF
--- a/models/dave_robot_models/description/glider_slocum/model.sdf
+++ b/models/dave_robot_models/description/glider_slocum/model.sdf
@@ -206,10 +206,10 @@
       <mQ>-20</mQ>
       <nR>-32</nR>
       <!-- cross terms -->
-      <yR>150</yR>
+      <!-- <yR>150</yR>
       <zQ>-100</zQ>
       <mW>37</mW>
-      <nV>-34</nV>
+      <nV>-34</nV> -->
 
       <!-- Quadratic Drag Coefficients -->
       <xUabsU>0</xUabsU>


### PR DESCRIPTION
This PR fixes the glider Slocum drift issue - 

Issue - When the glider Slocum was launched, it would drift along the x-axis up to a certain point before coming to a stop.

Fix - It was done by commenting out  **cross term linear force drag Coefficients** in these [lines](https://github.com/IOES-Lab/dave/blob/05254569ac0d89e3010224643fb788915e28f538/models/dave_robot_models/description/glider_slocum/model.sdf#L208C7-L212C23).

Run the following code for testing - 
`ros2 launch dave_demos dave_robot.launch.py x:=4 z:=-1.5 namespace:=glider_slocum world_name:=dave_ocean_waves paused:=false`
