### PR TITLE
Fixes Underwater Camera Plugin which sets the ROS2 node name statically, which doesn't allow to have multiples

### DIFF
--- a/gazebo/dave_gz_sensor_plugins/src/UnderwaterCamera.cc
+++ b/gazebo/dave_gz_sensor_plugins/src/UnderwaterCamera.cc
@@ -104,13 +104,6 @@ void UnderwaterCamera::Configure(
   gzdbg << "dave_gz_sensor_plugins::UnderwaterCamera::Configure on entity: " << _entity
         << std::endl;
 
-  if (!rclcpp::ok())
-  {
-    rclcpp::init(0, nullptr);
-  }
-
-  this->ros_node_ = std::make_shared<rclcpp::Node>("underwater_camera_node");
-
   auto rgbdCamera = _ecm.Component<gz::sim::components::RgbdCamera>(_entity);
   if (!rgbdCamera)
   {
@@ -132,6 +125,14 @@ void UnderwaterCamera::Configure(
           << "a null sensor." << std::endl;
     return;
   }
+
+  if (!rclcpp::ok())
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  std::string rosNodeName = sensorSdf.Name() + "_node";
+  this->ros_node_ = std::make_shared<rclcpp::Node>(rosNodeName);
 
   if (this->dataPtr->topic.empty())
   {


### PR DESCRIPTION
When adding multiple underwater camera plugins to a model sdf the output throws a warning as:

`[gazebo-1] [WARN] [1732716498.287779827] [rcl.logging_rosout]: Publisher already registered for node name: 'underwater_camera_node'. If this is due to multiple nodes with the same name then all logs for the logger named 'underwater_camera_node' will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.`

This is caused by setting the ros node name statically. This pull request fixes that by taking the sdf sensor name as a node name. For example:

``` xml
<sensor type="rgbd_camera" name="camera_front">
  <!-- other parameters -->
  <plugin
    filename="UnderwaterCamera"
    name="dave_gz_sensor_plugins::UnderwaterCamera">
    <attenuationR>0.8</attenuationR>
    <attenuationG>0.5</attenuationG>
    <attenuationB>0.2</attenuationB>
    <!-- Murky Coastal Waters -->
    <backgroundR>85</backgroundR>
    <backgroundG>107</backgroundG>
    <backgroundB>47</backgroundB>
  </plugin>
</sensor>
```

will result in a ros2 node name: `camera_front_node`.