### PR TITLE
Cuda acceleration

### DIFF
--- a/extras/ros-jazzy-gz-harmonic-install.sh
+++ b/extras/ros-jazzy-gz-harmonic-install.sh
@@ -88,6 +88,7 @@ sudo apt update && apt install -y \
     ros-$DIST-ros2-controllers \
     ros-$DIST-teleop-tools \
     ros-$DIST-urdfdom-py \
+    ros-$DIST-marine-acoustic-msgs \
     ros-dev-tools
 
 echo

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
@@ -32,15 +32,9 @@ if(CUDAToolkit_FOUND)
   find_package(sensor_msgs REQUIRED)
   find_package(geometry_msgs REQUIRED)
   find_package(rosidl_default_generators REQUIRED)
-  find_package(PCL REQUIRED)
-  find_package(pcl_conversions REQUIRED)
   find_package(OpenCV REQUIRED)
   find_package(marine_acoustic_msgs REQUIRED)
   find_package(cv_bridge REQUIRED)
-
-  include_directories(${PCL_INCLUDE_DIRS})
-  link_directories(${PCL_LIBRARY_DIRS})
-  add_definitions(${PCL_DEFINITIONS})
 
   set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
   set(GZ_RENDERING_VER ${gz-rendering8_VERSION_MAJOR})
@@ -88,7 +82,6 @@ if(CUDAToolkit_FOUND)
   endif()
 
   target_link_libraries(${PROJECT_NAME}
-    ${PCL_LIBRARIES}
     ${CUDA_LIBRARIES}
     ${CUDA_CUFFT_LIBRARIES}
     ${CUBLAS_LIB}
@@ -107,8 +100,6 @@ if(CUDAToolkit_FOUND)
     rclcpp
     sensor_msgs
     rosidl_default_generators
-    PCL
-    pcl_conversions
     OpenCV
     marine_acoustic_msgs
     geometry_msgs

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
@@ -73,7 +73,14 @@ if(CUDAToolkit_FOUND)
     ${gz-transport${GZ_TRANSPORT_VER}_INCLUDE_DIRS}
     ${gz-sim${GZ_SIM_VER}_INCLUDE_DIRS}
   )
-  target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES})
+
+  find_library(CUBLAS_LIB cublas
+  HINTS ${CUDAToolkit_LIBRARY_DIR} /usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu /usr/lib)
+  if(NOT CUBLAS_LIB)
+    message(FATAL_ERROR "cuBLAS not found")
+  endif()
+
+  target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${CUBLAS_LIB})
 
   install(TARGETS ${PROJECT_NAME}
     DESTINATION lib/${PROJECT_NAME}

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
@@ -2,21 +2,22 @@ cmake_minimum_required(VERSION 3.11.0 FATAL_ERROR)
 
 # Suppress developer warnings for the entire workspace.
 set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS TRUE CACHE BOOL "Suppress developer warnings" FORCE)
-# Set CMP0144 to NEW to ensure find_package uses upper-case <PACKAGENAME>_ROOT variables.
 cmake_policy(SET CMP0144 NEW)
 
 project(multibeam_sonar)
 
+set(CUDA_ARCHITECTURE "60" CACHE STRING "Target CUDA SM version")
+
 find_package(ament_cmake REQUIRED)
 find_package(CUDAToolkit QUIET)
 
-if(CUDAToolkit_FOUND)
+if(BUILD_WITH_CUDA AND CUDAToolkit_FOUND)
+
   enable_language(CUDA)
   find_package(CUDA REQUIRED)
   message(STATUS "CUDA found, enabling CUDA support.")
   include_directories(${CUDA_INCLUDE_DIRS})
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -arch=sm_60")
-
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -arch=sm_${CUDA_ARCHITECTURE}")
   find_package(gz-cmake3 REQUIRED)
   find_package(gz-sim8 REQUIRED)
   find_package(gz-sensors8 REQUIRED)
@@ -36,7 +37,6 @@ if(CUDAToolkit_FOUND)
   link_directories(${PCL_LIBRARY_DIRS})
   add_definitions(${PCL_DEFINITIONS})
 
-  # Set version variables
   set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
   set(GZ_RENDERING_VER ${gz-rendering8_VERSION_MAJOR})
   set(GZ_SENSORS_VER ${gz-sensors8_VERSION_MAJOR})
@@ -62,7 +62,9 @@ if(CUDAToolkit_FOUND)
   )
 
   set_target_properties(${PROJECT_NAME}
-                          PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+    PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+  )
 
   target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -75,12 +77,17 @@ if(CUDAToolkit_FOUND)
   )
 
   find_library(CUBLAS_LIB cublas
-  HINTS ${CUDAToolkit_LIBRARY_DIR} /usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu /usr/lib)
+    HINTS ${CUDAToolkit_LIBRARY_DIR} /usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu /usr/lib)
   if(NOT CUBLAS_LIB)
     message(FATAL_ERROR "cuBLAS not found")
   endif()
 
-  target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} ${CUDA_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${CUBLAS_LIB})
+  target_link_libraries(${PROJECT_NAME}
+    ${PCL_LIBRARIES}
+    ${CUDA_LIBRARIES}
+    ${CUDA_CUFFT_LIBRARIES}
+    ${CUBLAS_LIB}
+  )
 
   install(TARGETS ${PROJECT_NAME}
     DESTINATION lib/${PROJECT_NAME}
@@ -103,14 +110,12 @@ if(CUDAToolkit_FOUND)
     cv_bridge
   )
 
-
-  # Environment hooks
   ament_environment_hooks(
     "${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in"
   )
 
 else()
-  message(STATUS "CUDA Toolkit not found: Skipping CUDA-specific targets")
+  message(STATUS "CUDA Toolkit not found or disabled: Skipping CUDA-specific targets")
 endif()
 
 ament_package()

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CUDA_ARCHITECTURE "60" CACHE STRING "Target CUDA SM version")
 find_package(ament_cmake REQUIRED)
 find_package(CUDAToolkit QUIET)
 
-if(BUILD_WITH_CUDA AND CUDAToolkit_FOUND)
+if(CUDAToolkit_FOUND)
 
   enable_language(CUDA)
   find_package(CUDA REQUIRED)

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.cc
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.cc
@@ -48,11 +48,7 @@
 #include "MultibeamSonarSensor.hh"
 #include "sonar_calculation_cuda.cuh"
 
-#include <pcl/features/normal_3d.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
-#include <pcl_conversions/pcl_conversions.h>
+#include <sys/stat.h>
 #include <cv_bridge/cv_bridge.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <marine_acoustic_msgs/msg/ping_info.hpp>

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.cc
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.cc
@@ -372,6 +372,9 @@ bool MultibeamSonarSensor::Implementation::InitializeBeamArrangement(MultibeamSo
   this->debugFlag = sensorElement->Get<bool>("debugFlag", false).first;
   gzmsg << "Debug: " << this->debugFlag << std::endl;
 
+  this->blazingFlag = sensorElement->Get<bool>("blazingSonarImage", false).first;
+  gzmsg << "BlazingSonarImage: " << this->blazingFlag << std::endl;
+
   this->pointCloudTopicName =
     sensorElement->Get<std::string>("pointCloudTopicName", "point_cloud").first;
   gzmsg << "pointCloudTopicName: " << this->pointCloudTopicName << std::endl;
@@ -647,16 +650,6 @@ bool MultibeamSonarSensor::Implementation::InitializeBeamArrangement(MultibeamSo
   RCLCPP_INFO_STREAM(this->ros_node_->get_logger(), "");
 
   // -- Pre calculations for sonar -- //
-
-  // Random number generator
-  gzmsg << "Initializing random number generator..." << std::endl;
-  this->randImage = cv::Mat(this->pointMsg.height(), this->pointMsg.width(), CV_32FC2);
-  uint64 randN = static_cast<uint64>(std::rand());
-  gzmsg << "Random seed: " << randN << std::endl;
-  cv::theRNG().state = randN;
-  cv::RNG rng = cv::theRNG();
-  rng.fill(this->randImage, cv::RNG::NORMAL, 0.0f, 1.0f);
-  gzmsg << "Random image generated with normal distribution." << std::endl;
 
   // Hamming window
   gzmsg << "Computing Hamming window for " << this->nFreq << " frequencies." << std::endl;
@@ -1069,7 +1062,6 @@ void MultibeamSonarSensor::Implementation::ComputeSonarImage()
   CArray2D P_Beams = NpsGazeboSonar::sonar_calculation_wrapper(
     this->pointCloudImage,        // cv::Mat& depth_image (the point cloud image)
     normal_image,                 // cv::Mat& normal_image
-    this->randImage,              // cv::Mat& rand_image
     hPixelSize,                   // hPixelSize
     vPixelSize,                   // vPixelSize
     hFOV,                         // hFOV
@@ -1093,7 +1085,9 @@ void MultibeamSonarSensor::Implementation::ComputeSonarImage()
     this->window,                 // _window
     this->beamCorrector,          // _beamCorrector
     this->beamCorrectorSum,       // _beamCorrectorSum
-    this->debugFlag);
+    this->debugFlag,              // debugFlag
+    this->blazingFlag             // _blazingFlag
+  );
 
   // For calc time measure
   auto stop = std::chrono::high_resolution_clock::now();

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.hh
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.hh
@@ -160,6 +160,9 @@ private:
     int ray_nElevationRays;
     float * rangeVector;
 
+    // Sonar image parameters
+    bool blazingFlag;
+
     // Debug flags and reflectivity
     bool debugFlag;
     bool constMu;

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
@@ -541,12 +541,6 @@ CArray2D sonar_calculation_wrapper(
   cudaEventDestroy(start1);
   cudaEventDestroy(stop1);
 
-  printf("Total sonar calculation (kernel) time: %.3f ms\n", milliseconds);
-
-  // Copy back data from destination device meory to OpenCV output image
-  SAFE_CALL(
-    cudaMemcpy(P_Beams, d_P_Beams, P_Beams_Bytes, cudaMemcpyDeviceToHost), "CUDA Memcpy Failed");
-
   if (debugFlag)
   {
     stop = std::chrono::high_resolution_clock::now();

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
@@ -41,7 +41,7 @@
 // FOR DEBUG -- DEV VERSION
 #include <fstream>
 
-std::ofstream debugLog("debug_timings.txt", std::ios::app);
+std::ofstream debugLog("debug_timings.txt");
 
 #define BLOCK_SIZE 32
 

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
@@ -556,10 +556,10 @@ CArray2D sonar_calculation_wrapper(
     float ms = static_cast<float>(dcount) / 1000.0f;
 
     printf("GPU Sonar Computation Time %lld/100 [s]\n", dcount / 10000);
-    printf("GPU Sonar Summation Time: %.3f ms\n", ms);
+    printf("GPU Sonar Computation Time: %.3f ms\n", ms);
 
     debugLog << "GPU Sonar Computation Time " << dcount / 10000 << "/100 [s]\n";
-    debugLog << "GPU Sonar Summation Time: " << ms << " ms\n";
+    debugLog << "GPU Sonar Computation Time: " << ms << " ms\n";
 
     start = std::chrono::high_resolution_clock::now();
   }

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cu
@@ -236,10 +236,13 @@ __global__ void sonar_calculation(
       acos(normal[2]);  // compute_incidence(ray_azimuthAngle, ray_elevationAngle, normal);
 
     // ----- Point scattering model ------ //
-    curandState state;
+    curandStatePhilox4_32_10_t state;
     curand_init(seed, beam * height + ray, 0, &state);  // seed, unique id, offset, state
-    float xi_z = curand_normal(&state);                 // standard normal random value
-    float xi_y = curand_normal(&state);                 // standard normal random value
+
+    float4 xi = curand_normal4(&state);  // standard 4 normal random values
+
+    float xi_z = xi.x;
+    float xi_y = xi.y;
 
     // Calculate amplitude
     thrust::complex<float> randomAmps = thrust::complex<float>(xi_z / sqrt(2.0), xi_y / sqrt(2.0));

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cuh
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cuh
@@ -45,12 +45,11 @@ void free_cuda_memory();
 
 /// \brief Sonar Claculation Function Wrapper
 CArray2D sonar_calculation_wrapper(
-  const cv::Mat & depth_image, const cv::Mat & normal_image, const cv::Mat & rand_image,
-  double _hPixelSize, double _vPixelSize, double _hFOV, double _vFOV,
-  double _beam_azimuthAngleWidth, double _beam_elevationAngleWidth, double _ray_azimuthAngleWidth,
-  float * _ray_elevationAngles, double _ray_elevationAngleWidth, double _soundSpeed,
-  double _maxDistance, double _sourceLevel, int _nBeams, int _nRays, int _raySkips,
-  double _sonarFreq, double _bandwidth, int _nFreq, const cv::Mat & reflectivity_image,
-  double _attenuation, float * _window, float ** _beamCorrector, float _beamCorrectorSum,
-  bool _debugFlag);
+  const cv::Mat & depth_image, const cv::Mat & normal_image, double _hPixelSize, double _vPixelSize,
+  double _hFOV, double _vFOV, double _beam_azimuthAngleWidth, double _beam_elevationAngleWidth,
+  double _ray_azimuthAngleWidth, float * _ray_elevationAngles, double _ray_elevationAngleWidth,
+  double _soundSpeed, double _maxDistance, double _sourceLevel, int _nBeams, int _nRays,
+  int _raySkips, double _sonarFreq, double _bandwidth, int _nFreq,
+  const cv::Mat & reflectivity_image, double _attenuation, float * _window, float ** _beamCorrector,
+  float _beamCorrectorSum, bool _debugFlag, bool _blazingFlag);
 }  // namespace NpsGazeboSonar

--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cuh
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/sonar_calculation_cuda.cuh
@@ -40,6 +40,9 @@ typedef std::valarray<CArray> CArray2D;
 /// \brief CUDA Device Check Function Wrapper
 void check_cuda_init_wrapper(void);
 
+/// \brief CUDA Free Memory Function
+void free_cuda_memory();
+
 /// \brief Sonar Claculation Function Wrapper
 CArray2D sonar_calculation_wrapper(
   const cv::Mat & depth_image, const cv::Mat & normal_image, const cv::Mat & rand_image,

--- a/models/dave_robot_models/description/bluerov2_heavy/model.sdf
+++ b/models/dave_robot_models/description/bluerov2_heavy/model.sdf
@@ -165,8 +165,9 @@
             <maxDistance>10</maxDistance>
             <raySkips>10</raySkips>
             <sensorGain>0.02</sensorGain>
-            <writeLog>true</writeLog>
-            <debugFlag>true</debugFlag>
+            <blazingSonarImage>true</blazingSonarImage>
+            <writeLog>false</writeLog>
+            <debugFlag>false</debugFlag>
             <writeFrameInterval>5</writeFrameInterval>
             <!-- ROS publication topics -->
             <pointCloudTopicName>point_cloud</pointCloudTopicName>

--- a/models/dave_sensor_models/description/blueview_p900/model.sdf
+++ b/models/dave_sensor_models/description/blueview_p900/model.sdf
@@ -90,8 +90,9 @@
             <maxDistance>10</maxDistance>
             <raySkips>10</raySkips>
             <sensorGain>0.02</sensorGain>
-            <writeLog>true</writeLog>
-            <debugFlag>true</debugFlag>
+            <blazingSonarImage>true</blazingSonarImage>
+            <writeLog>false</writeLog>
+            <debugFlag>false</debugFlag>
             <writeFrameInterval>5</writeFrameInterval>
             <!-- ROS publication topics -->
             <pointCloudTopicName>point_cloud</pointCloudTopicName>


### PR DESCRIPTION
This PR aims to improve the CUDA code used for the sonar calculations, focusing on reducing execution time. The following changes were implemented:

### 1. Optimized Matrix Multiplication

Previously, the matrix multiplication was performed using the custom kernel.

```
__global__ void gpu_matrix_mult(float *a, float *b, float *c, int m, int n, int k)
```
This was replaced with [cublasSgemm](https://docs.nvidia.com/cuda/cublas/#cublas-t-gemmex) for matrix multiplication.
It provides acceleration, but is more significant for larger matrices (e.g., higher numbers of beams).
See commit: [add sgemm acceleration](https://github.com/IOES-Lab/dave/commit/50cded8c18714d4cde062d5a0425494d25689cc8)

### 2. Ray Summation Optimization

Original kernel using column-wise reduction and kernel launch (2 x nBeams launches per sonar frame):
```
template <typename T>
__global__ void column_sums_reduce(
    const T *__restrict__ in, T *__restrict__ out, size_t width, size_t height)
```

New kernel (1 launch per sonar frame):

```
__global__ void reduce_beams_kernel(
    const thrust::complex<float> *__restrict__ d_P_Beams,
    float *d_P_Beams_F_real, float *d_P_Beams_F_imag,
    int nBeams, int nFreq, int nRaysSkipped)
```
- Combined real and imaginary summation in a single kernel (reduce_beams_kernel) using `thrust::complex<float>`.
- Accumulate sums in registers and reduce in shared memory, writing once per beam-frequency to global memory.
- Fewer __syncthreads() and kernel launches, reducing synchronization and stall latency.
- Removed multiple `memcpy` calls

In the tested GPU (NVIDIA GeForce MX330), this part of the code provided the highest speedup (4–5× faster).

See commit: [add new summation kernel](https://github.com/IOES-Lab/dave/commit/5aea3e1b1a7571708cd61232498ea6d89dc3c152)

### 3. Reuse Global Buffers

Another change was reusing constant-size buffers (whose dimensions are known at plugin launch) instead of allocating memory for every frame. Now, the buffers are allocated at launch and freed when the plugin is destroyed.

See commits: [reuse buffers](https://github.com/IOES-Lab/dave/commit/5aea3e1b1a7571708cd61232498ea6d89dc3c152) and [add more global buffers](https://github.com/IOES-Lab/dave/commit/edd14e0e645ac260bc4134130e60c1a1bbf356bf).

### 4. Replace exp() and use intrinsic functions
One change made to the sonar calculation kernel that provided a 9× speedup (reducing execution time from 30 ms to 3.15 ms on the GeForce MX330) was switching to intrinsic math functions inside the for loop. First, ` exp()`  was replaced with` __sincosf()`. `exp(i * theta)`, which is equivalent to `cos(theta) + i*sin(theta)`, so the new code computes the real and imaginary parts directly with `__sincosf`, avoiding the complex exponential. Additionally, regular division was replaced with `__fdividef`.

See commit: [change complex exp calculation](https://github.com/IOES-Lab/dave/commit/edd14e0e645ac260bc4134130e60c1a1bbf356bf)
See commit: [replace functions to use gpu intrinsic ones](https://github.com/IOES-Lab/dave/commit/0f20acd5608aa0e4da01a0eab0255ae530b50712)
## How to test it 

Follow the demos in the Wiki page: [DAVE ROS 2 Multibeam Sonar Plugin Wiki](https://dave-ros2.notion.site/Multibeam-Sonar-Plugin-223661362ab2803b873bda4878fc55a8). For example:
```
ros2 launch dave_multibeam_sonar_demo multibeam_sonar_demo.launch.py
```
Use this branch to run the demos; a .txt file with the debug times will be generated to evaluate performance.

**Tocompare this branch’s performance with the old CUDA code (which generates the same .txt), checkout the branch [cuda-performance](https://github.com/IOES-Lab/dave/tree/cuda-performance) and run the same demos.**



