### PR TITLE
Ardusub installation script added

### DIFF
--- a/.docker/jazzy.amd64.dockerfile
+++ b/.docker/jazzy.amd64.dockerfile
@@ -80,10 +80,10 @@ WORKDIR /
 # Set up bashrc for root
 RUN echo "source /opt/ros/jazzy/setup.bash" >> /root/.bashrc && \
     echo "source /opt/dave_ws/install/setup.bash" >> /root/.bashrc && \
-    echo "export PATH=/opt/ardupilot_ws/ardupilot/Tools/autotest:\$PATH" >> /root/.bashrc && \
-    echo "export PATH=/opt/ardupilot_ws/ardupilot/build/sitl/bin:\$PATH" >> /root/.bashrc && \
-    echo "export GZ_SIM_SYSTEM_PLUGIN_PATH=/opt/ardupilot_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH" >> /root/.bashrc && \
-    echo "export GZ_SIM_RESOURCE_PATH=/opt/ardupilot_ws/ardupilot_gazebo/models:/opt/ardupilot_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH" >> /root/.bashrc && \
+    echo "export PATH=/opt/ardusub_ws/ardupilot/Tools/autotest:\$PATH" >> /root/.bashrc && \
+    echo "export PATH=/opt/ardusub_ws/ardupilot/build/sitl/bin:\$PATH" >> /root/.bashrc && \
+    echo "export GZ_SIM_SYSTEM_PLUGIN_PATH=/opt/ardusub_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH" >> /root/.bashrc && \
+    echo "export GZ_SIM_RESOURCE_PATH=/opt/ardusub_ws/ardupilot_gazebo/models:/opt/ardusub_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH" >> /root/.bashrc && \
     echo "export PS1='\[\e[1;36m\]\u@DAVE_docker\[\e[0m\]\[\e[1;34m\](\$(hostname | cut -c1-12))\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ '" >> /root/.bashrc
 
 RUN touch /root/.dave_entrypoint && printf '\033[1;36m =====\n' >> /root/.dave_entrypoint && \

--- a/.docker/jazzy.arm64v8.dockerfile
+++ b/.docker/jazzy.arm64v8.dockerfile
@@ -159,10 +159,10 @@ RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \
     echo "source $DAVE_UNDERLAY/install/setup.bash" >> ~/.bashrc && \
     echo "export GEOGRAPHICLIB_GEOID_PATH=/usr/local/share/GeographicLib/geoids" >> ~/.bashrc && \
     echo "export PYTHONPATH=\$PYTHONPATH:/opt/gazebo/install/lib/python" >> ~/.bashrc && \
-    echo "export PATH=/home/$USER/ardupilot_ws/ardupilot/Tools/autotest:\$PATH" >> ~/.bashrc && \
-    echo "export PATH=/home/$USER/ardupilot_ws/ardupilot/build/sitl/bin:\$PATH" >> ~/.bashrc && \
-    echo "export GZ_SIM_SYSTEM_PLUGIN_PATH=/home/$USER/ardupilot_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH" >> ~/.bashrc && \
-    echo "export GZ_SIM_RESOURCE_PATH=/home/$USER/ardupilot_ws/ardupilot_gazebo/models:/home/$USER/ardupilot_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH" >> ~/.bashrc && \
+    echo "export PATH=/home/$USER/ardusub_ws/ardupilot/Tools/autotest:\$PATH" >> ~/.bashrc && \
+    echo "export PATH=/home/$USER/ardusub_ws/ardupilot/build/sitl/bin:\$PATH" >> ~/.bashrc && \
+    echo "export GZ_SIM_SYSTEM_PLUGIN_PATH=/home/$USER/ardusub_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH" >> ~/.bashrc && \
+    echo "export GZ_SIM_RESOURCE_PATH=/home/$USER/ardusub_ws/ardupilot_gazebo/models:/home/$USER/ardusub_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH" >> ~/.bashrc && \
     echo "\n\n" >> ~/.bashrc && echo "if [ -d ~/HOST ]; then chown $USER:$USER ~/HOST; fi" >> ~/.bashrc  && \
     echo "export PS1='\[\e[1;36m\]\u@DAVE_docker\[\e[0m\]\[\e[1;34m\](\$(hostname | cut -c1-12))\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ '" >>  ~/.bashrc
 

--- a/extras/ardusub-ubuntu-install-local.sh
+++ b/extras/ardusub-ubuntu-install-local.sh
@@ -9,11 +9,11 @@ export USER=docker
 # Really should do version pinning but Sub-4.5 is waaaay behind master
 # (e.g. it doesn't know about "noble" yet)
 export ARDUPILOT_RELEASE=master
-mkdir -p "/home/$USER/ardupilot_ws" && cd "/home/$USER/ardupilot_ws" || exit
+mkdir -p "/home/$USER/ardusub_ws" && cd "/home/$USER/ardusub_ws" || exit
 git clone -b $ARDUPILOT_RELEASE https://github.com/ArduPilot/ardupilot.git --recurse-submodules
 
 # Install ArduSub dependencies
-cd "/home/$USER/ardupilot_ws/ardupilot" || exit
+cd "/home/$USER/ardusub_ws/ardupilot" || exit
 export SKIP_AP_EXT_ENV=1 SKIP_AP_GRAPHIC_ENV=1 SKIP_AP_COV_ENV=1 SKIP_AP_GIT_CHECK=1
 # Do not install the STM development tools
 export DO_AP_STM_ENV=0
@@ -26,20 +26,20 @@ modules/waf/waf-light configure --board sitl \
   && modules/waf/waf-light build --target bin/ardusub
 
 # Clone ardupilot_gazebo code
-cd "/home/$USER/ardupilot_ws" || exit
+cd "/home/$USER/ardusub_ws" || exit
 git clone https://github.com/ArduPilot/ardupilot_gazebo.git
 
 # Install ardupilot_gazebo plugin
 # Check if the directory creation was successful
-mkdir -p "/home/$USER/ardupilot_ws/ardupilot_gazebo/build" \
-  && cd "/home/$USER/ardupilot_ws/ardupilot_gazebo/build" || exit
+mkdir -p "/home/$USER/ardusub_ws/ardupilot_gazebo/build" \
+  && cd "/home/$USER/ardusub_ws/ardupilot_gazebo/build" || exit
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make -j2
 
 # Add results of ArduSub build
-export PATH=/home/$USER/ardupilot_ws/ardupilot/build/sitl/bin:\$PATH
+export PATH=/home/$USER/ardusub_ws/ardupilot/build/sitl/bin:\$PATH
 # Optional: add autotest to the PATH, helpful for running sim_vehicle.py
-export PATH=/home/$USER/ardupilot_ws/ardupilot/Tools/autotest:\$PATH
+export PATH=/home/$USER/ardusub_ws/ardupilot/Tools/autotest:\$PATH
 # Add ardupilot_gazebo plugin
-export GZ_SIM_SYSTEM_PLUGIN_PATH=/home/$USER/ardupilot_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH
+export GZ_SIM_SYSTEM_PLUGIN_PATH=/home/$USER/ardusub_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH
 # Add ardupilot_gazebo models and worlds
-export GZ_SIM_RESOURCE_PATH=/home/$USER/ardupilot_ws/ardupilot_gazebo/models:/home/$USER/ardupilot_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH
+export GZ_SIM_RESOURCE_PATH=/home/$USER/ardusub_ws/ardupilot_gazebo/models:/home/$USER/ardusub_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH

--- a/extras/ardusub-ubuntu-install.sh
+++ b/extras/ardusub-ubuntu-install.sh
@@ -7,11 +7,11 @@ source /opt/ros/jazzy/setup.bash
 # Really should do version pinning but Sub-4.5 is waaaay behind master
 # (e.g. it doesn't know about "noble" yet)
 export ARDUPILOT_RELEASE=master
-mkdir -p "/opt/ardupilot_ws" && cd "/opt/ardupilot_ws" || exit
+mkdir -p "/opt/ardusub_ws" && cd "/opt/ardusub_ws" || exit
 git clone -b $ARDUPILOT_RELEASE https://github.com/ArduPilot/ardupilot.git --recurse-submodules
 
 # Install ArduSub dependencies
-cd "/opt/ardupilot_ws/ardupilot" || exit
+cd "/opt/ardusub_ws/ardupilot" || exit
 export SKIP_AP_EXT_ENV=1 SKIP_AP_GRAPHIC_ENV=1 SKIP_AP_COV_ENV=1 SKIP_AP_GIT_CHECK=1
 # Do not install the STM development tools
 export DO_AP_STM_ENV=0
@@ -24,20 +24,20 @@ modules/waf/waf-light configure --board sitl \
   && modules/waf/waf-light build --target bin/ardusub
 
 # Clone ardupilot_gazebo code
-cd "/opt/ardupilot_ws" || exit
+cd "/opt/ardusub_ws" || exit
 git clone https://github.com/ArduPilot/ardupilot_gazebo.git
 
 # Install ardupilot_gazebo plugin
 # Check if the directory creation was successful
-mkdir -p "/opt/ardupilot_ws/ardupilot_gazebo/build" \
-  && cd "/opt/ardupilot_ws/ardupilot_gazebo/build" || exit
+mkdir -p "/opt/ardusub_ws/ardupilot_gazebo/build" \
+  && cd "/opt/ardusub_ws/ardupilot_gazebo/build" || exit
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && make -j2
 
 # Add results of ArduSub build
-export PATH=/opt/ardupilot_ws/ardupilot/build/sitl/bin:\$PATH
+export PATH=/opt/ardusub_ws/ardupilot/build/sitl/bin:\$PATH
 # Optional: add autotest to the PATH, helpful for running sim_vehicle.py
-export PATH=/opt/ardupilot_ws/ardupilot/Tools/autotest:\$PATH
+export PATH=/opt/ardusub_ws/ardupilot/Tools/autotest:\$PATH
 # Add ardupilot_gazebo plugin
-export GZ_SIM_SYSTEM_PLUGIN_PATH=/opt/ardupilot_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH
+export GZ_SIM_SYSTEM_PLUGIN_PATH=/opt/ardusub_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH
 # Add ardupilot_gazebo models and worlds
-export GZ_SIM_RESOURCE_PATH=/opt/ardupilot_ws/ardupilot_gazebo/models:/opt/ardupilot_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH
+export GZ_SIM_RESOURCE_PATH=/opt/ardusub_ws/ardupilot_gazebo/models:/opt/ardusub_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH

--- a/extras/ros-jazzy-gz-harmonic-install.sh
+++ b/extras/ros-jazzy-gz-harmonic-install.sh
@@ -92,9 +92,28 @@ sudo apt update && apt install -y \
     ros-dev-tools
 
 echo
+echo -e "\033[96m(4/4) ------------     Install Ardusub    ---------------\033[0m"
+
+# Install ardusub(local)
+sudo mkdir -p /opt/ardusub_ws && cd /opt/ardusub_ws || exit
+wget https://raw.githubusercontent.com/IOES-Lab/dave/ros2/extras/ardusub-ubuntu-install-local.sh
+sudo chmod +x ardusub-ubuntu-install-local.sh && sudo bash ./ardusub-ubuntu-install-local.sh
+
+# Mavros install
+sudo apt-get -y install ros-jazzy-mavros*
+sudo mkdir -p /opt/mavros_ws && cd /opt/mavros_ws || exit
+sudo wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh
+sudo chmod +x install_geographiclib_datasets.sh && sudo bash ./install_geographiclib_datasets.sh
+
+# Environment variables setup (add to ~/.bashrc or ~/.zshrc)
+echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \
+echo "export PATH=/opt/ardusub_ws/ardupilot/Tools/autotest:\$PATH" >> ~/.bashrc && \
+echo "export PATH=/opt/ardusub_ws/ardupilot/build/sitl/bin:\$PATH" >> ~/.bashrc && \
+echo "export GZ_SIM_SYSTEM_PLUGIN_PATH=/opt/ardusub_ws/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_PLUGIN_PATH" >> ~/.bashrc && \
+echo "export GZ_SIM_RESOURCE_PATH=/opt/ardusub_ws/ardupilot_gazebo/models:/opt/ardusub_ws/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH" >> ~/.bashrc
+
+echo
 echo -e "\033[32m============================================================\033[0m"
 echo -e "\033[32mROS-Gazebo Framework Installation completed. Awesome! 🤘🚀 \033[0m"
-echo -e "Following command will set-up ROS environment variables to run it"
-echo -e "\033[95msource /opt/ros/jazzy/setup.bash\033[0m"
 echo -e "You may check ROS, and Gazebo version installed with \033[33mprintenv ROS_DISTRO\033[0m and \033[33mecho \$GZ_VERSION\033[0m"
 echo


### PR DESCRIPTION
This pull request standardizes the workspace directory used for ArduSub-related installations and environment variables across the project. Specifically, it replaces all references to `ardupilot_ws` with `ardusub_ws` in installation scripts and Dockerfiles, ensuring consistent paths and reducing confusion or errors during setup. Additionally, it updates environment variable exports and adds a new Ardusub installation step to the ROS-Gazebo setup script.

Key changes include:

**Workspace Path Standardization:**

* All scripts and Dockerfiles now use `/opt/ardusub_ws` or `/home/$USER/ardusub_ws` instead of the previous `ardupilot_ws` paths for cloning, building, and referencing ArduSub and ardupilot_gazebo repositories. This affects the following files: `.docker/jazzy.amd64.dockerfile` [[1]](diffhunk://#diff-77c2b424d9d744c7c9a9b36dc611ffe8e2e0858e38d3e3ca0e2caff71543f0f5L83-R86) `.docker/jazzy.arm64v8.dockerfile` [[2]](diffhunk://#diff-dc251926e20c473be6faa2cbb210de46690bc2cc07d6e207492b96df29a9cc50L162-R165) `extras/ardusub-ubuntu-install.sh` [[3]](diffhunk://#diff-9f9729ef220fbb79066d2544f13a399ec1c8e461c5dafe567d1f95cc913ec7f6L10-R14) [[4]](diffhunk://#diff-9f9729ef220fbb79066d2544f13a399ec1c8e461c5dafe567d1f95cc913ec7f6L27-R43) and `extras/ardusub-ubuntu-install-local.sh` [[5]](diffhunk://#diff-9a5ee058fe584204f868961126389224802d520befa6bbec552f42bcc168c403L12-R16) [[6]](diffhunk://#diff-9a5ee058fe584204f868961126389224802d520befa6bbec552f42bcc168c403L29-R45).

**Environment Variable Updates:**

* All environment variable exports in the affected scripts and Dockerfiles now point to the new `ardusub_ws` paths, ensuring that tools and plugins reference the correct locations. [[1]](diffhunk://#diff-77c2b424d9d744c7c9a9b36dc611ffe8e2e0858e38d3e3ca0e2caff71543f0f5L83-R86) [[2]](diffhunk://#diff-dc251926e20c473be6faa2cbb210de46690bc2cc07d6e207492b96df29a9cc50L162-R165) [[3]](diffhunk://#diff-9f9729ef220fbb79066d2544f13a399ec1c8e461c5dafe567d1f95cc913ec7f6L27-R43) [[4]](diffhunk://#diff-9a5ee058fe584204f868961126389224802d520befa6bbec552f42bcc168c403L29-R45)

**Installation Script Enhancements:**

* The `extras/ros-jazzy-gz-harmonic-install.sh` script now includes a dedicated Ardusub installation step using the new local install script, and sets up the corresponding environment variables in the user's `.bashrc`.

These changes improve maintainability and clarity for anyone setting up or working with ArduSub in this project.