### PR TITLE
wrong source fix

### DIFF
--- a/.docker/jazzy.amd64.dockerfile
+++ b/.docker/jazzy.amd64.dockerfile
@@ -54,7 +54,7 @@ RUN bash install.sh
 RUN apt-get update && \
     apt-get -y install --no-install-recommends ros-jazzy-mavros* \
     && rm -rf /tmp/*
-WORKDIR /opt/mavros_ws
+WORKDIR /tmp
 RUN wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh && \
     bash ./install_geographiclib_datasets.sh
 

--- a/.docker/jazzy.arm64v8.dockerfile
+++ b/.docker/jazzy.arm64v8.dockerfile
@@ -129,7 +129,7 @@ extras/background.png && \
 
 # Install Ardupilot - Ardusub
 USER docker
-RUN wget -O /tmp/install.sh https://raw.githubusercontent.com/IOES-Lab/dave/$BRANCH/extras/ardusub-ubuntu-install.sh
+RUN wget -O /tmp/install.sh https://raw.githubusercontent.com/IOES-Lab/dave/$BRANCH/extras/ardusub-ubuntu-install-local.sh
 RUN chmod +x /tmp/install.sh && bash /tmp/install.sh
 
 # Set up Dave workspace

--- a/.docker/jazzy.arm64v8.dockerfile
+++ b/.docker/jazzy.arm64v8.dockerfile
@@ -111,7 +111,7 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
 RUN apt-get update && \
     apt-get -y install --no-install-recommends ros-jazzy-mavros* \
     && rm -rf /tmp/*
-WORKDIR /opt/mavros_ws
+WORKDIR /tmp
 RUN wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh && \
     bash ./install_geographiclib_datasets.sh
 
@@ -129,7 +129,7 @@ extras/background.png && \
 
 # Install Ardupilot - Ardusub
 USER docker
-RUN wget -O /tmp/install.sh https://raw.githubusercontent.com/IOES-Lab/dave/$BRANCH/extras/ardusub-ubuntu-install-local.sh
+RUN wget -O /tmp/install.sh https://raw.githubusercontent.com/IOES-Lab/dave/$BRANCH/extras/ardusub-ubuntu-install.sh
 RUN chmod +x /tmp/install.sh && bash /tmp/install.sh
 
 # Set up Dave workspace
@@ -154,8 +154,6 @@ RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" && colcon build
 # Set User as user
 USER docker
 RUN echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc && \
-    echo "source /opt/gazebo/install/setup.bash" >> ~/.bashrc && \
-    echo "source /opt/mavros/install/setup.bash" >> ~/.bashrc && \
     echo "source $DAVE_UNDERLAY/install/setup.bash" >> ~/.bashrc && \
     echo "export GEOGRAPHICLIB_GEOID_PATH=/usr/local/share/GeographicLib/geoids" >> ~/.bashrc && \
     echo "export PYTHONPATH=\$PYTHONPATH:/opt/gazebo/install/lib/python" >> ~/.bashrc && \


### PR DESCRIPTION
This pull request makes several adjustments to the Dockerfiles for both AMD64 and ARM64v8 builds, focusing on workspace setup, script sourcing, and installation procedures. The main themes are improving build consistency and updating installation scripts.

Workspace and build setup changes:

* Changed the working directory from `/opt/mavros_ws` to `/tmp` before running the `install_geographiclib_datasets.sh` script in both `.docker/jazzy.amd64.dockerfile` and `.docker/jazzy.arm64v8.dockerfile` to ensure script execution in a temporary location. [[1]](diffhunk://#diff-77c2b424d9d744c7c9a9b36dc611ffe8e2e0858e38d3e3ca0e2caff71543f0f5L57-R57) [[2]](diffhunk://#diff-dc251926e20c473be6faa2cbb210de46690bc2cc07d6e207492b96df29a9cc50L114-R114)

Shell environment configuration:

* Removed sourcing of Gazebo and Mavros setup scripts from `.bashrc` in `.docker/jazzy.arm64v8.dockerfile`, simplifying the environment setup for the user.