### PR TITLE
fix: reset sonarRawDataMsg each frame to stop beam_directions size gr…

### DIFF
--- a/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.cc
+++ b/gazebo/dave_gz_multibeam_sonar/multibeam_sonar/MultibeamSonarSensor.cc
@@ -1166,6 +1166,8 @@ void MultibeamSonarSensor::Implementation::ComputeSonarImage()
 
   rclcpp::Time now = this->ros_node_->now();
 
+  this->sonarRawDataMsg = marine_acoustic_msgs::msg::ProjectedSonarImage();
+
   this->sonarRawDataMsg.header.frame_id = this->frameId;
 
   this->sonarRawDataMsg.header.stamp.sec = static_cast<int32_t>(now.seconds());


### PR DESCRIPTION
`beam_directions` was appended via `push_back()` on a persistent member message every frame, causing it to grow unboundedly. 

Reinitializing sonarRawDataMsg to a default message at the start of each ComputeSonarImage call ensures the vector is cleared before repopulating.