### PR TITLE
Fix ~/.ros_ardusub_env/env breaking on zsh

### DIFF
--- a/extras/ros-jazzy-gz-harmonic-install.sh
+++ b/extras/ros-jazzy-gz-harmonic-install.sh
@@ -131,7 +131,11 @@ ENV_FILE="$ENV_DIR/env"
 mkdir -p "$ENV_DIR"
 
 cat > "$ENV_FILE" <<'EOF'
-source /opt/ros/jazzy/setup.bash
+if [ -n "$ZSH_VERSION" ]; then
+    source /opt/ros/jazzy/setup.zsh
+else
+    source /opt/ros/jazzy/setup.bash
+fi
 export PATH=/opt/ardusub_ws/ardupilot/Tools/autotest:$PATH
 export PATH=/opt/ardusub_ws/ardupilot/build/sitl/bin:$PATH
 export GEOGRAPHICLIB_GEOID_PATH=/usr/share/GeographicLib/geoids


### PR DESCRIPTION
The current `env` file unconditionally does `source /opt/ros/jazzy/setup.bash`. That setup script uses `${BASH_SOURCE[0]}` to find its own location, which is empty in zsh - so `AMENT_CURRENT_PREFIX` resolves to whatever the shell's cwd is at startup (usually `$HOME`), and you get a `no such file or directory: $HOME/setup.sh` error on every new zsh shell. ROS doesn't get sourced via this path; the export lines below still apply, so it sort of half-works and is easy to miss.

The installer already picks the right rc file based on `$TARGET_SHELL`, but the `env` body was hardcoded to bash.

### Fix
Detect the shell at source time inside `env` and pick `setup.zsh` vs `setup.bash` accordingly:

```sh
if [ -n "$ZSH_VERSION" ]; then
    source /opt/ros/jazzy/setup.zsh
else
    source /opt/ros/jazzy/setup.bash
fi
```

Doing it at source time (rather than at install time via `TARGET_SHELL`) means the same `env` works if someone happens to source it from the other shell, and survives a default-shell change without a reinstall.

This could get unwieldy if extended for each shell a user can source. Might recommend removing this source line, and assume user sources in their `.*rc` files - or doing a check, and confirming it is sourced in the rc files prior to writing to `env`

### Scope
One-line behaviour change in the heredoc that writes `env`. No reformatting, no other touches.

### Tests
No new tests. Verified manually:
- Fresh zsh shell: no error, `ros2` available, `AMENT_PREFIX_PATH` populated.
- Fresh bash shell: unchanged behaviour.